### PR TITLE
Fix typo in slide

### DIFF
--- a/high-performance-go-workshop.slide
+++ b/high-performance-go-workshop.slide
@@ -17,7 +17,7 @@ The materials for this presentation are available on GitHub:
 
 You are encouraged to remix, transform, or build upon the material, providing you give appropriate credit and distribute your contributions under the same license.
 
-If you have suggestions or corrections to this presentation, please raise [[https://github.com/davecheney/high-performance-go-workshop/isues][an issue on the GitHub project]].
+If you have suggestions or corrections to this presentation, please raise [[https://github.com/davecheney/high-performance-go-workshop/issues][an issue on the GitHub project]].
 
 * Agenda
 


### PR DESCRIPTION
Not correct url.

#### Before
```
https://github.com/davecheney/high-performance-go-workshop/isues
```

#### After
```
https://github.com/davecheney/high-performance-go-workshop/issues
```


Thank you for today !